### PR TITLE
Deprecate ::set-output command

### DIFF
--- a/azure-devops-npm/action.yml
+++ b/azure-devops-npm/action.yml
@@ -25,7 +25,7 @@ runs:
   steps:
     - id: set_vars
       run: |
-        echo "::set-output name=azure_url::$(echo 'pkgs.dev.azure.com/${{ inputs.organization }}/_packaging/${{ inputs.registry }}/npm')"
+        echo "azure_url=pkgs.dev.azure.com/${{ inputs.organization }}/_packaging/${{ inputs.registry }}/npm" >> $GITHUB_OUTPUT
       shell: bash
     - run: |
         echo "registry=https://${{ steps.set_vars.outputs.azure_url }}/registry/" > ${{ inputs.npmrc-path }}


### PR DESCRIPTION
Deprecate ::set-output command according to the docs:
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter